### PR TITLE
Feat/category

### DIFF
--- a/src/application/controllers/category/createCategoryController.ts
+++ b/src/application/controllers/category/createCategoryController.ts
@@ -6,14 +6,14 @@ import { createCategoryBody, createCategorySchema } from './schemas/createCatego
 
 @Injectable()
 @Schema(createCategorySchema)
-export class CreateCategoryController extends Controller<'private', createCategoryController.Response> {
+export class CreateCategoryController extends Controller<'private', CreateCategoryController.Response> {
   constructor(private readonly createCategoryUseCase: CreateCategoryUseCase) {
     super();
   }
 
-  protected override async handle({ body }: Controller.Request<'private', createCategoryBody>): Promise<Controller.Response<createCategoryController.Response>> {
-    const category = body;
-    await this.createCategoryUseCase.execute(category);
+  protected override async handle({ body, storeId }: Controller.Request<'private', createCategoryBody>): Promise<Controller.Response<CreateCategoryController.Response>> {
+    const { name } = body;
+    await this.createCategoryUseCase.execute({ name, storeId });
 
     return {
       statusCode: 201,
@@ -22,6 +22,6 @@ export class CreateCategoryController extends Controller<'private', createCatego
 
 }
 
-export namespace createCategoryController {
+export namespace CreateCategoryController {
   export type Response = null
 }

--- a/src/application/controllers/category/schemas/createCategorySchema.ts
+++ b/src/application/controllers/category/schemas/createCategorySchema.ts
@@ -3,9 +3,6 @@ import z from 'zod';
 export const createCategorySchema = z.object({
   name: z.string()
     .min(1, 'O nome é obrigatório.'),
-  storeId: z.string()
-    .min(1, 'O storeId é obrigatório.'),
-
 });
 
 export type createCategoryBody = z.infer<typeof createCategorySchema>;

--- a/src/main/adapters/lambdaHttpAdapter.ts
+++ b/src/main/adapters/lambdaHttpAdapter.ts
@@ -17,7 +17,7 @@ export function lambdaHttpAdapter(controller: Controller<any, unknown>) {
       const queryParams = event.queryStringParameters ?? {};
       const storeId = (
         'authorizer' in event.requestContext
-          ? event.requestContext.authorizer.jwt.claims.internalId as string
+          ? event.requestContext.authorizer.jwt.claims.storeId as string
           : null
       );
 

--- a/src/main/functions/category/createCategory.ts
+++ b/src/main/functions/category/createCategory.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata';
 
-import { CreateCategoryController } from '@application/controllers/category/createCategoryController';
+import { CreateCategoryController } from '@application/controllers/category/CreateCategoryController';
 import { Registry } from '@kernel/di/Registry';
 import { lambdaHttpAdapter } from '@main/adapters/lambdaHttpAdapter';
 


### PR DESCRIPTION
## Descrição

- Refatoração dos claims do authorizer:
  - Renomeado de `internalId` para `storeId`.

- Refatoração no controller de criação de categoria:
  - Alterado nome do arquivo de `createCategoryController.ts` para `CreateCategoryController.ts` para seguir padrão PascalCase.
  - Removido `storeId` do schema de criação de categoria (`createCategorySchema`).
  - `storeId` agora é injetado diretamente no controller via contexto (authorizer claims) e não mais pelo corpo da requisição.

## 📦 Alterações

- `src/main/adapters/lambdaHttpAdapter.ts`
  - Renomeado claim `internalId` → `storeId`.

- `src/application/controllers/category/CreateCategoryController.ts`
  - Atualizado o nome do arquivo.
  - Atualizado a namespace para `CreateCategoryController`.
  - Removido `storeId` do body e injetado via request.

- `src/application/controllers/category/schemas/createCategorySchema.ts`
  - Removido `storeId` do schema.

- `src/main/functions/category/createCategory.ts`
  - Atualizado import para refletir mudança no nome do arquivo.

