### PR TITLE
Feat/product

### DIFF
--- a/drizzle/0014_rapid_mentallo.sql
+++ b/drizzle/0014_rapid_mentallo.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "products" ADD COLUMN "input_type" varchar(50);

--- a/drizzle/meta/0014_snapshot.json
+++ b/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,613 @@
+{
+  "id": "1e2b2a64-824d-4d8d-b00b-2447d5e18f64",
+  "prevId": "b28954b7-bb63-4ee0-9f40-f3e93f1343ea",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "store_id": {
+          "name": "store_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(244)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon_path": {
+          "name": "icon_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "categories_store_id_name_idx": {
+          "name": "categories_store_id_name_idx",
+          "columns": [
+            {
+              "expression": "store_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "categories_store_id_stores_id_fk": {
+          "name": "categories_store_id_stores_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "stores",
+          "columnsFrom": [
+            "store_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "categories_store_id_name_unique": {
+          "name": "categories_store_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "store_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "store_id": {
+          "name": "store_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_path": {
+          "name": "image_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "barcode": {
+          "name": "barcode",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_price": {
+          "name": "cost_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stock_alert": {
+          "name": "stock_alert",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_stock": {
+          "name": "current_stock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "input_type": {
+          "name": "input_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "product_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "products_store_id_idx": {
+          "name": "products_store_id_idx",
+          "columns": [
+            {
+              "expression": "store_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_barcode_idx": {
+          "name": "products_barcode_idx",
+          "columns": [
+            {
+              "expression": "barcode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_store_category_idx": {
+          "name": "products_store_category_idx",
+          "columns": [
+            {
+              "expression": "store_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "products_store_barcode_idx": {
+          "name": "products_store_barcode_idx",
+          "columns": [
+            {
+              "expression": "store_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "barcode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_store_id_stores_id_fk": {
+          "name": "products_store_id_stores_id_fk",
+          "tableFrom": "products",
+          "tableTo": "stores",
+          "columnsFrom": [
+            "store_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "products_category_id_categories_id_fk": {
+          "name": "products_category_id_categories_id_fk",
+          "tableFrom": "products",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "products_barcode_unique": {
+          "name": "products_barcode_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "barcode"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stock_movements": {
+      "name": "stock_movements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "store_id": {
+          "name": "store_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_price": {
+          "name": "cost_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "movement_date": {
+          "name": "movement_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stock_movements_store_id_idx": {
+          "name": "stock_movements_store_id_idx",
+          "columns": [
+            {
+              "expression": "store_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stock_movements_product_id_idx": {
+          "name": "stock_movements_product_id_idx",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stock_movements_movement_date_idx": {
+          "name": "stock_movements_movement_date_idx",
+          "columns": [
+            {
+              "expression": "movement_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stock_movements_store_id_stores_id_fk": {
+          "name": "stock_movements_store_id_stores_id_fk",
+          "tableFrom": "stock_movements",
+          "tableTo": "stores",
+          "columnsFrom": [
+            "store_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "stock_movements_product_id_products_id_fk": {
+          "name": "stock_movements_product_id_products_id_fk",
+          "tableFrom": "stock_movements",
+          "tableTo": "products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stores": {
+      "name": "stores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(244)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stores_account_id_accounts_id_fk": {
+          "name": "stores_account_id_accounts_id_fk",
+          "tableFrom": "stores",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stores_name_unique": {
+          "name": "stores_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.product_status": {
+      "name": "product_status",
+      "schema": "public",
+      "values": [
+        "UPLOADING",
+        "QUEUED",
+        "PROCESSING",
+        "SUCCESS",
+        "FAILED"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1753136683941,
       "tag": "0013_magenta_mad_thinker",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1753218781873,
+      "tag": "0014_rapid_mentallo",
+      "breakpoints": true
     }
   ]
 }

--- a/sls/functions/product.yml
+++ b/sls/functions/product.yml
@@ -14,3 +14,11 @@ listProducts:
         method: GET
         authorizer:
           name: CognitoAuthorizer
+getProductById:
+  handler: src/main/functions/product/getProductById.handler
+  events:
+    - httpApi:
+        path: /products/{productId}
+        method: GET
+        authorizer:
+          name: CognitoAuthorizer

--- a/src/application/controllers/product/GetProductByIdController.ts
+++ b/src/application/controllers/product/GetProductByIdController.ts
@@ -1,0 +1,60 @@
+import { Controller } from '@application/contracts/Controller';
+import { Product } from '@application/entities/Product';
+import { GetProductByIdUseCase } from '@application/usecases/product/GetProductByIdUseCase';
+
+import { Injectable } from '@kernel/decorators/Injectable';
+
+@Injectable()
+export class GetProductByIdController extends Controller<'private', GetProductByIdController.Response> {
+  constructor(private readonly getProductByIdUseCase: GetProductByIdUseCase) {
+    super();
+  }
+
+  async handle({ storeId, params }: GetProductByIdController.Request): Promise<Controller.Response<GetProductByIdController.Response>> {
+    const { productId } = params;
+
+    const { product } = await this.getProductByIdUseCase.execute({
+      storeId,
+      productId,
+    });
+
+    return {
+      statusCode: 200,
+      body: {
+        product,
+      },
+    };
+  }
+}
+
+export namespace GetProductByIdController {
+  export type Params = {
+    productId: string;
+  }
+
+  export type Request = Controller.Request<
+    'private',
+    Record<string, unknown>,
+    GetProductByIdController.Params
+  >;
+
+  export type Response = {
+    product: {
+      id: string;
+      storeId: string;
+      categoryId: string;
+      status: Product.Status;
+      inputType: Product.InputType;
+      name: string;
+      price: number;
+      costPrice: number;
+      currentStock: number;
+      stockAlert: number;
+      inputFileKey: string;
+      barcode?: string;
+      description?: string;
+      createdAt?: Date;
+      updatedAt?: Date;
+    };
+  }
+}

--- a/src/application/usecases/product/GetProductByIdUseCase.ts
+++ b/src/application/usecases/product/GetProductByIdUseCase.ts
@@ -1,0 +1,69 @@
+import { Product } from '@application/entities/Product';
+import { ResourceNotFound } from '@application/errors/application/ResourceNotFound ';
+import { ProductRepository } from '@infra/database/drizzle/repositories/ProductRepository';
+import { Injectable } from '@kernel/decorators/Injectable';
+
+@Injectable()
+export class GetProductByIdUseCase {
+  constructor(
+    private readonly productRepository: ProductRepository,
+  ) { }
+
+  async execute({
+    storeId,
+    productId,
+  }: GetProductByIdUseCase.Input): Promise<GetProductByIdUseCase.Output> {
+    const product = await this.productRepository.findById(storeId, productId);
+
+    if (!product) {
+      throw new ResourceNotFound('product not found.');
+    }
+
+    return {
+      product: {
+        id: product.id,
+        storeId: product.storeId,
+        categoryId: product.categoryId,
+        name: product.name,
+        price: Number(product.price),
+        status: product.status as Product.Status,
+        inputType: product.inputType as Product.InputType,
+        costPrice: Number(product.costPrice),
+        currentStock: product.currentStock,
+        stockAlert: product.stockAlert,
+        inputFileKey: product.inputFileKey ?? '',
+        barcode: product.barcode ?? '',
+        description: product.description ?? '',
+        createdAt: product.createdAt,
+        updatedAt: product.updatedAt,
+      },
+    };
+  }
+}
+
+export namespace GetProductByIdUseCase {
+  export type Input = {
+    storeId: string,
+    productId: string,
+  };
+
+  export type Output = {
+    product: {
+      id: string;
+      storeId: string;
+      categoryId: string;
+      status: Product.Status;
+      inputType: Product.InputType;
+      name: string;
+      price: number;
+      costPrice: number;
+      currentStock: number;
+      stockAlert: number;
+      inputFileKey: string;
+      barcode?: string;
+      description?: string;
+      createdAt?: Date;
+      updatedAt?: Date;
+    };
+  };
+}

--- a/src/infra/database/drizzle/repositories/ProductRepository.ts
+++ b/src/infra/database/drizzle/repositories/ProductRepository.ts
@@ -11,6 +11,29 @@ export type ProductDb = InferSelectModel<typeof productsTable>;
 export class ProductRepository {
   constructor(private readonly db: DrizzleClient) { }
 
+  async create(trx: UnitOfWorkTransaction, product: Product): Promise<void> {
+    const transaction = trx;
+    await transaction.insert(productsTable).values({
+      ...product,
+      price: product.price.toString(),
+      costPrice: product.costPrice.toString(),
+    });
+  }
+
+  async findById(storeId: string, productId: string): Promise<ProductDb | null> {
+    const result = await this.db.httpClient
+      .select()
+      .from(productsTable)
+      .where(
+        and(
+          eq(productsTable.id, productId),
+          eq(productsTable.storeId, storeId),
+        ),
+      );
+
+    return result[0] ?? null;
+  }
+
   async findByName(storeId: string, name: string): Promise<ProductDb | null> {
     const result = await this.db.httpClient
       .select()
@@ -23,14 +46,5 @@ export class ProductRepository {
       );
 
     return result[0] ?? null;
-  }
-
-  async create(trx: UnitOfWorkTransaction, product: Product): Promise<void> {
-    const transaction = trx;
-    await transaction.insert(productsTable).values({
-      ...product,
-      price: product.price.toString(),
-      costPrice: product.costPrice.toString(),
-    });
   }
 }

--- a/src/infra/database/drizzle/schema/product.ts
+++ b/src/infra/database/drizzle/schema/product.ts
@@ -36,6 +36,7 @@ export const productsTable = pgTable(
     costPrice: numeric('cost_price', { precision: 10, scale: 2 }).notNull(),
     stockAlert: integer('stock_alert').notNull().default(0),
     currentStock: integer('current_stock').notNull().default(0),
+    inputType: varchar('input_type', { length: 50 }),
     status: productStatusEnum('status').notNull(),
     description: text('description'),
     createdAt: timestamp('created_at').defaultNow().notNull(),

--- a/src/main/functions/product/getProductById.ts
+++ b/src/main/functions/product/getProductById.ts
@@ -1,0 +1,8 @@
+import 'reflect-metadata';
+
+import { GetProductByIdController } from '@application/controllers/product/GetProductByIdController';
+import { Registry } from '@kernel/di/Registry';
+import { lambdaHttpAdapter } from '@main/adapters/lambdaHttpAdapter';
+
+const controller = Registry.getInstance().resolve(GetProductByIdController);
+export const handler = lambdaHttpAdapter(controller);


### PR DESCRIPTION
# 🛠️ Get Product By ID + Campo inputType no Produto

## 📝 Descrição

Esta PR adiciona a funcionalidade de busca de produto por ID, além de introduzir um novo campo na tabela de produtos chamado `inputType`, que permite controlar dinamicamente o tipo de entrada associada a cada produto. As principais entregas são:

- Novo endpoint `GET /products/{productId}` exposto via AWS Lambda e protegido com o Cognito Authorizer;
- Implementação do use case `GetProductByIdUseCase` com tratamento de erro `ResourceNotFound`;
- Criação do controller `GetProductByIdController` com retorno detalhado dos dados do produto;
- Adição do campo `inputType` na tabela `products`, via migration Drizzle;
- Atualização do schema `productsTable` no Drizzle;
- Atualização do `ProductRepository` com método `findById`.

## ✅ O que foi alterado

- 🔧 **Migration**: adicionada coluna `input_type` à tabela `products`;
- 🧩 **Schema (Drizzle)**: campo `inputType` incluído na definição da tabela;
- 📚 **Repository**: novo método `findById` criado no `ProductRepository`;
- 🚀 **Use Case**: implementado `GetProductByIdUseCase` com lógica de retorno e tipagens fortes;
- 📦 **Controller**: criado `GetProductByIdController` para lidar com requisições HTTP;
- ☁️ **Handler Lambda**: adicionado handler `getProductById` com rota `/products/{productId}`;



