### PR TITLE
Feat/category

### DIFF
--- a/sls/functions/category.yml
+++ b/sls/functions/category.yml
@@ -6,3 +6,11 @@ createCategory:
         method: POST
         authorizer:
           name: CognitoAuthorizer
+listCategory:
+  handler: src/main/functions/category/listCategory.handler
+  events:
+    - httpApi:
+        path: /category
+        method: GET
+        authorizer:
+          name: CognitoAuthorizer

--- a/src/application/controllers/category/ListCategoriesController.ts
+++ b/src/application/controllers/category/ListCategoriesController.ts
@@ -1,0 +1,60 @@
+import { Controller } from '@application/contracts/Controller';
+import { Category } from '@application/entities/Category';
+import { FilterCategoryQuery } from '@application/query/FilterCategoryQuery copy';
+import { Injectable } from '@kernel/decorators/Injectable';
+
+@Injectable()
+export class ListCategoryController extends Controller<'private', ListCategoryController.Response> {
+  constructor(private readonly filterCategoryQuery: FilterCategoryQuery) {
+    super();
+  }
+
+  async handle({ storeId, queryParams }: Controller.Request<'private'>): Promise<Controller.Response<ListCategoryController.Response>> {
+    const {
+      name,
+      page = 1,
+      limit = 10,
+      order = 'asc',
+    } = queryParams as ListCategoryController.CategoryParams;
+
+  const result = await this.filterCategoryQuery.execute({
+    storeId,
+    page: Math.max(1, page),
+    limit: Math.min(limit, 100),
+    order,
+    name,
+  });
+
+  return {
+    statusCode: 200,
+    body: {
+      categories: result.categories,
+      meta: {
+        total: result.total,
+        page: result.page,
+        limit: result.limit,
+        totalPages: result.totalPages,
+      },
+    },
+  };
+
+  }
+}
+export namespace ListCategoryController {
+  export type Response = {
+    categories: Category[] | undefined;
+    meta: {
+      total: number,
+      page: number,
+      limit: number,
+      totalPages: number,
+    },
+  }
+
+  export type CategoryParams = {
+    name?: string;
+    page: number;
+    limit: number;
+    order : 'asc' | 'desc'
+  }
+}

--- a/src/application/query/FilterCategoryQuery copy.ts
+++ b/src/application/query/FilterCategoryQuery copy.ts
@@ -1,0 +1,104 @@
+import { Category } from '@application/entities/Category';
+import { DrizzleClient } from '@infra/clients/drizzleClient';
+import { TCategory } from '@infra/database/drizzle/schema/categories';
+import { Injectable } from '@kernel/decorators/Injectable';
+import { SQL, sql } from 'drizzle-orm';
+
+@Injectable()
+export class FilterCategoryQuery {
+  constructor(private readonly db: DrizzleClient) { }
+
+  async execute({
+    storeId,
+    name,
+    page,
+    limit,
+    order = 'asc',
+  }: FilterCategoryQuery.Input): Promise<FilterCategoryQuery.Output> {
+
+    if (!storeId) {
+      throw new Error('StoreId is required');
+    }
+
+    const filters: SQL[] = [sql`c.store_id = ${storeId}`];
+
+    if (name && name.trim() !== '') {
+      filters.push(sql`c.name ILIKE ${`%${name.trim()}%`}`);
+    }
+
+    const whereClause = sql.join(filters, sql` AND `);
+    const limitClause = limit ? sql`LIMIT ${limit}` : sql``;
+    const offsetClause = page && limit ? sql`OFFSET ${(page - 1) * limit}` : sql``;
+    const orderDirection = order === 'desc' ? sql`DESC` : sql`ASC`;
+
+    const query = sql`
+      WITH filtered_data AS (
+        SELECT c.*, COUNT(*) OVER() as total_count
+        FROM categories c
+        WHERE ${whereClause}
+        ORDER BY c.name ${orderDirection}
+        ${limitClause} ${offsetClause}
+      )
+      SELECT
+        id,
+        name,
+        store_id,
+        icon_path,
+        active,
+        created_at,
+        COALESCE(total_count, 0) as total_count
+      FROM filtered_data
+    `;
+
+    const result = await this.db.httpClient.execute(query);
+    const rows = result.rows as (TCategory & { total_count: number })[];
+
+    if (!rows.length) {
+      return {
+        categories: [],
+        total: 0,
+        page: page,
+        limit: limit,
+        totalPages: 0,
+      };
+    }
+
+    const total = Number(rows[0].total_count);
+    const totalPages = Math.ceil(total / limit);
+
+    const categories = rows.map(row => new Category({
+      id: row.id,
+      name: row.name,
+      storeId: row.storeId,
+      active: row.active,
+      iconPath: row.iconPath,
+
+    }));
+
+    return {
+      categories,
+      total,
+      page: page,
+      limit: limit,
+      totalPages,
+    };
+  }
+}
+
+export namespace FilterCategoryQuery {
+  export type Input = {
+    storeId: string;
+    name?: string;
+    limit: number;
+    page: number;
+    order?: 'asc' | 'desc';
+  };
+
+  export type Output = {
+    categories: Category[];
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+  };
+}

--- a/src/application/usecases/category/ListCategoriesUseCase.ts
+++ b/src/application/usecases/category/ListCategoriesUseCase.ts
@@ -1,0 +1,50 @@
+import { Category } from '@application/entities/Category';
+import { FilterCategoryQuery } from '@application/query/FilterCategoryQuery copy';
+
+import { Injectable } from '@kernel/decorators/Injectable';
+
+@Injectable()
+export class ListCategoriesUseCase {
+  constructor(private readonly filterCategoryQuery: FilterCategoryQuery) {}
+
+  async execute(input: ListCategoriesUseCase.Input): Promise<ListCategoriesUseCase.Output> {
+
+    const result = await this.filterCategoryQuery.execute({
+      storeId: input.storeId,
+      page: input.page,
+      limit: input.limit,
+      order: input.order,
+      name: input.name,
+    });
+
+    return {
+      categories: result.categories,
+      meta: {
+        total: result.total,
+        page: result.page,
+        limit: result.limit,
+        totalPages: result.totalPages,
+      },
+    };
+  }
+}
+
+export namespace ListCategoriesUseCase {
+  export type Input = {
+    storeId: string;
+    name?: string;
+    page: number;
+    limit: number;
+    order: 'asc' | 'desc';
+  };
+
+  export type Output = {
+    categories: Category[];
+    meta: {
+      total: number;
+      page: number;
+      limit: number;
+      totalPages: number;
+    };
+  };
+}

--- a/src/infra/database/drizzle/schema/categories.ts
+++ b/src/infra/database/drizzle/schema/categories.ts
@@ -1,3 +1,4 @@
+import { InferSelectModel } from 'drizzle-orm';
 import { boolean, index, pgTable, timestamp, unique, uuid, varchar } from 'drizzle-orm/pg-core';
 import { storesTable } from './stores';
 
@@ -19,3 +20,5 @@ export const categoriesTable = pgTable(
     unique('categories_store_id_name_unique').on(table.storeId, table.name),
   ],
 );
+
+export type TCategory = InferSelectModel<typeof categoriesTable>;

--- a/src/main/functions/category/listCategory.ts
+++ b/src/main/functions/category/listCategory.ts
@@ -1,0 +1,9 @@
+import 'reflect-metadata';
+
+import { ListCategoryController } from '@application/controllers/category/ListCategoriesController';
+import { Registry } from '@kernel/di/Registry';
+import { lambdaHttpAdapter } from '@main/adapters/lambdaHttpAdapter';
+
+const controller = Registry.getInstance().resolve(ListCategoryController);
+
+export const handler = lambdaHttpAdapter(controller);


### PR DESCRIPTION
# PR - Implementação de Listagem e Filtro de Categorias

## 📌 Descrição
Este PR implementa a **listagem de categorias** com suporte a:
- Filtros opcionais por nome (`?name=...`)
- Paginação (`?page=...&limit=...`)
- Ordenação (`?order=asc|desc`)
- Retorno de metadados de paginação (`total`, `page`, `limit`, `totalPages`)

Foram adicionados um **controller** e uma **query** performática utilizando **Drizzle ORM** e **PostgreSQL**.

---

## 🔨 Alterações realizadas
### `FilterCategoryQuery`
- Criado método `execute` para buscar categorias por `storeId`.
- Implementado **filtro por nome** opcional (`ILIKE '%termo%'`).
- Adicionada **paginação opcional** com `LIMIT` e `OFFSET`.
- Implementada **contagem total** utilizando `COUNT(*) OVER()` para evitar queries duplicadas.
- Retorno com `categories`, `total`, `page`, `limit` e `totalPages`.

### `ListCategoryController`
- Adicionado controller para expor rota de listagem de categorias.
- Suporte a query params:  
  - `name` → filtro por nome  
  - `page` (default `1`)  
  - `limit` (default `10`, máximo `100`)  
  - `order` (`asc` ou `desc`)  
